### PR TITLE
fix old and not working widget urls with the updated urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,57 +5,57 @@ Replace the server ID with your own Discord server ID.
 This can be found in `Server Settings > Widget > Server ID` 
 
 ## Shield
-![Discord Shield](https://discordapp.com/api/guilds/127498813903601664/widget.png?style=shield)
+![Discord Shield](https://discord.com/api/guilds/127498813903601664/widget.png?style=shield)
 
 ### Markdown
 ```
-![Discord Shield](https://discordapp.com/api/guilds/[SERVER ID]/widget.png?style=shield)
+![Discord Shield](https://discord.com/api/guilds/[SERVER ID]/widget.png?style=shield)
 ```
 ### HTML
 ```html
-<img src="https://discordapp.com/api/guilds/[SERVER ID]/widget.png?style=shield" alt="Discord Shield"/>
+<img src="https://discord.com/api/guilds/[SERVER ID]/widget.png?style=shield" alt="Discord Shield"/>
 ```
 ## Banner 1
-![Discord Banner 1](https://discordapp.com/api/guilds/127498813903601664/widget.png?style=banner1)
+![Discord Banner 1](https://discord.com/api/guilds/127498813903601664/widget.png?style=banner1)
 
 ### Markdown
 ```
-![Discord Banner 1](https://discordapp.com/api/guilds/[SERVER ID]/widget.png?style=banner1)
+![Discord Banner 1](https://discord.com/api/guilds/[SERVER ID]/widget.png?style=banner1)
 ```
 ### HTML
 ```html
-<img src="https://discordapp.com/api/guilds/[SERVER ID]/widget.png?style=banner1" alt="Discord Banner 1"/>
+<img src="https://discord.com/api/guilds/[SERVER ID]/widget.png?style=banner1" alt="Discord Banner 1"/>
 ```
 ## Banner 2
-![Discord Banner 2](https://discordapp.com/api/guilds/127498813903601664/widget.png?style=banner2)
+![Discord Banner 2](https://discord.com/api/guilds/127498813903601664/widget.png?style=banner2)
 
 ### Markdown
 ```
-![Discord Banner 2](https://discordapp.com/api/guilds/[SERVER ID]/widget.png?style=banner2)
+![Discord Banner 2](https://discord.com/api/guilds/[SERVER ID]/widget.png?style=banner2)
 ```
 ### HTML
 ```html
-<img src="https://discordapp.com/api/guilds/[SERVER ID]/widget.png?style=banner2" alt="Discord Banner 2"/>
+<img src="https://discord.com/api/guilds/[SERVER ID]/widget.png?style=banner2" alt="Discord Banner 2"/>
 ```
 ## Banner 3
-![Discord Banner 3](https://discordapp.com/api/guilds/127498813903601664/widget.png?style=banner3)
+![Discord Banner 3](https://discord.com/api/guilds/127498813903601664/widget.png?style=banner3)
 
 ### Markdown
 ```
-![Discord Banner 3](https://discordapp.com/api/guilds/[SERVER ID]/widget.png?style=banner3)
+![Discord Banner 3](https://discord.com/api/guilds/[SERVER ID]/widget.png?style=banner3)
 ```
 ### HTML
 ```html
-<img src="https://discordapp.com/api/guilds/[SERVER ID]/widget.png?style=banner3" alt="Discord Banner 3"/>
+<img src="https://discord.com/api/guilds/[SERVER ID]/widget.png?style=banner3" alt="Discord Banner 3"/>
 ```
 ## Banner 4
-![Discord Banner 4](https://discordapp.com/api/guilds/127498813903601664/widget.png?style=banner4)
+![Discord Banner 4](https://discord.com/api/guilds/127498813903601664/widget.png?style=banner4)
 
 ### Markdown
 ```
-![Discord Banner 4](https://discordapp.com/api/guilds/[SERVER ID]/widget.png?style=banner4)
+![Discord Banner 4](https://discord.com/api/guilds/[SERVER ID]/widget.png?style=banner4)
 ```
 ### HTML
 ```html
-<img src="https://discordapp.com/api/guilds/[SERVER ID]/widget.png?style=banner4" alt="Discord Banner 4"/>
+<img src="https://discord.com/api/guilds/[SERVER ID]/widget.png?style=banner4" alt="Discord Banner 4"/>
 ```


### PR DESCRIPTION
`discordapp.com` doesn't work now but `discord.com` does.